### PR TITLE
Fixed a bug where the VS debugger was trying to download the latest s…

### DIFF
--- a/recipes-devtools/vsdbg/README.txt
+++ b/recipes-devtools/vsdbg/README.txt
@@ -1,0 +1,3 @@
+URL for the script to pull this debugger is located at:
+
+https://aka.ms/getvsdbgsh

--- a/recipes-devtools/vsdbg/vsdbg_16.2.10709.2.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.2.10709.2.inc
@@ -5,6 +5,10 @@
 SUMMARY = "Contains the binaries for Microsoft's Visual Studio Remote Debugger for Linux"
 HOMEPAGE = "https://visualstudio.microsoft.com/"
 
+SRC_URI += "https://vsdebugger.blob.core.windows.net/vsdbg-16-2-10709-2/GetVsDbg.sh;name=script"
+SRC_URI[script.md5sum] = "338a3dfa8e454bc16f032a848d0d157e"
+SRC_URI[script.sha256sum] = "45c10c66cbeea057246641e74879eff0b4d70e97478cafc5be11e9cfdea7a657"
+
 DOTNET_RUNTIME_ARCH = "none"
 DOTNET_RUNTIME_ARCH_arm = "arm"
 DOTNET_RUNTIME_ARCH_x86_64 = "x64"
@@ -14,6 +18,8 @@ require recipes-devtools/vsdbg/vsdbg_16.2.10709.2_${DOTNET_RUNTIME_ARCH}.inc
 
 do_install_append () {
 	echo "16.2.10709.2" > ${D}${ROOT_HOME}/.vs-debugger/vs2019/success.txt
+	echo "16.2.10709.2" > ${D}${ROOT_HOME}/.vs-debugger/vs2019/success_version.txt
+	echo "linux-${DOTNET_RUNTIME_ARCH}" > ${D}${ROOT_HOME}/.vs-debugger/vs2019/success_rid.txt
 	cd ${D}${ROOT_HOME}/.vs-debugger
 	ln -sf vs2019 vs2017u5
 }

--- a/recipes-devtools/vsdbg/vsdbg_16.2.10709.2_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.2.10709.2_arm.inc
@@ -3,8 +3,8 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2019
 ###################################################################################################
-SRC_URI = "https://vsdebugger.azureedge.net/vsdbg-16-2-10709-2/vsdbg-linux-arm.zip;subdir=vsdbg-${PV}"
+SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-2-10709-2/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
 
-SRC_URI[md5sum] = "8e2497708884ba7efb2baf1423981a81"
-SRC_URI[sha256sum] = "67c3f3f4fcb1aa66c673f472de3f799269acac30cab48df66618f3dd58542f99"
+SRC_URI[source.md5sum] = "8e2497708884ba7efb2baf1423981a81"
+SRC_URI[source.sha256sum] = "67c3f3f4fcb1aa66c673f472de3f799269acac30cab48df66618f3dd58542f99"
 

--- a/recipes-devtools/vsdbg/vsdbg_16.2.10709.2_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.2.10709.2_x64.inc
@@ -3,8 +3,8 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2019
 ###################################################################################################
-SRC_URI = "https://vsdebugger.azureedge.net/vsdbg-16-2-10709-2/vsdbg-linux-x64.zip;subdir=vsdbg-${PV}"
+SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-2-10709-2/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
 
-SRC_URI[md5sum] = "ec95b4e673253661de89b9da526d49bc"
-SRC_URI[sha256sum] = "c78a82b235f7a6c24363e3efbf75aff9e5c454d0791e2117e54f40dc8f82a322"
+SRC_URI[source.md5sum] = "ec95b4e673253661de89b9da526d49bc"
+SRC_URI[source.sha256sum] = "c78a82b235f7a6c24363e3efbf75aff9e5c454d0791e2117e54f40dc8f82a322"
 

--- a/recipes-devtools/vsdbg/vsdbg_16.x.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.x.inc
@@ -31,6 +31,7 @@ do_install_prepend () {
 	install -m 0644 ${S}/license.txt ${D}${ROOT_HOME}/.vs-debugger/vs2019/
 	install -m 0644 ${S}/ThirdPartyNotices.txt ${D}${ROOT_HOME}/.vs-debugger/vs2019/
 	install -m 0644 ${S}/version.txt ${D}${ROOT_HOME}/.vs-debugger/vs2019/
+	install -m 0755 ${WORKDIR}/GetVsDbg.sh ${D}${ROOT_HOME}/.vs-debugger/
 
 	install -d ${D}${ROOT_HOME}/.vs-debugger/vs2019/1028/
 	for file in ${S}/1028/*.dll; do


### PR DESCRIPTION
…cript file.

The vsdbg 16.2.10709 now grabs the corresponding GetVsDbg.sh script file and places it in the correct location. It also will add the success_version.txt and success_rid.txt files.