### PR TITLE
dotnet-core_5.x.x.inc: fix liblttng-ust.so.0 build issue

### DIFF
--- a/recipes-runtime/dotnet-core/dotnet-core_5.x.x.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_5.x.x.inc
@@ -11,7 +11,8 @@ S = "${WORKDIR}/dotnet-${PV}"
 
 require recipes-runtime/dotnet-core/dotnet-core_mit_5.x.x.inc
 
-DEPENDS = "zlib"
+# FIXME: patchelf-native must be removed if hack in do_install:append not required
+DEPENDS = "zlib patchelf-native"
 RDEPENDS:${PN} = "icu lttng-tools lttng-ust zlib libgssglue krb5 libgssapi-krb5"
 
 INSANE_SKIP:${PN} += "already-stripped libdir textrel"
@@ -68,5 +69,9 @@ do_install:append() {
 
 	cd ${D}${bindir}
 	ln -s ../share/dotnet/dotnet ${D}${bindir}/dotnet
+	
+	# FIXME: must be removed if the liblttng-ust library issue was fixed
+	# Hack to fix liblttng-ust dependency issues
+	patchelf --remove-needed liblttng-ust.so.0 ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App/${PV}/libcoreclrtraceptprovider.so
 }
 


### PR DESCRIPTION
Added same fix as for 6.x.x to build 5.x.x versions with kirkstone.