### PR TITLE
lttng does not seem to be runtime requirement for aspnet core. Accord…

### DIFF
--- a/recipes-runtime/aspnet-core/aspnet-core_8.x.x.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.x.x.inc
@@ -13,7 +13,7 @@ require recipes-runtime/aspnet-core/aspnet-core_mit_8.x.x.inc
 
 # FIXME: patchelf-native must be removed if hack in do_install:append not required
 DEPENDS = "zlib patchelf-native"
-RDEPENDS:${PN} = "lttng-tools lttng-ust zlib icu libssl"
+RDEPENDS:${PN} = "zlib icu libssl krb5"
 
 INSANE_SKIP:${PN} += "already-stripped libdir textrel"
 INSANE_SKIP:${PN}-dbg += "libdir"


### PR DESCRIPTION
Hello @RDunkley 

Thank you for your nice work so far.

lttng does not seem to be runtime requirement for aspnet core. According to MS kerberos is!

(https://github.com/dotnet/core/blob/main/release-notes/8.0/linux-packages.md)

Since I do not want to add packages I do not need to my Image I removed the dependency but added krb5 instead.

Regards