### PR TITLE
SRC_URI hostname change

### DIFF
--- a/recipes-devtools/vsdbg/vsdbg_15.7.20426.1_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_15.7.20426.1_arm.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2018
 ###################################################################################################
-SRC_URI = "https://vsdebugger.azureedge.net/vsdbg-15-7-20425-2/vsdbg-linux-arm.zip;subdir=vsdbg-${PV}"
+SRC_URI = "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-15-7-20425-2/vsdbg-linux-arm.zip;subdir=vsdbg-${PV}"
 
 SRC_URI[md5sum] = "7d56be537a8d061f56d6012799cc4b80"
 SRC_URI[sha256sum] = "14049dd1100f67cf892df540bbea79272afaf90fe3db3dd67a5730d7a965eea6"

--- a/recipes-devtools/vsdbg/vsdbg_15.7.20426.1_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_15.7.20426.1_x64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2018
 ###################################################################################################
-SRC_URI = "https://vsdebugger.azureedge.net/vsdbg-15-7-20425-2/vsdbg-linux-x64.zip;subdir=vsdbg-${PV}"
+SRC_URI = "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-15-7-20425-2/vsdbg-linux-x64.zip;subdir=vsdbg-${PV}"
 
 SRC_URI[md5sum] = "e8ef7f5c5307ffd086657a478c46b919"
 SRC_URI[sha256sum] = "c2f051aefc588cb65e72e25b9454a182c62f20ddfe7e25a35b57383ed2c40f35"

--- a/recipes-devtools/vsdbg/vsdbg_16.0.20419.1_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.0.20419.1_arm.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2019
 ###################################################################################################
-SRC_URI = "https://vsdebugger.azureedge.net/vsdbg-16-0-20419-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV}"
+SRC_URI = "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-0-20419-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV}"
 
 SRC_URI[md5sum] = "72bcbeb65c78c1aa6af105ccc0128b3e"
 SRC_URI[sha256sum] = "f0083959e34b6706fcabc2b2bade1ab3c90e3d542cd67d3d7a01fb251837ce56"

--- a/recipes-devtools/vsdbg/vsdbg_16.0.20419.1_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.0.20419.1_x64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2019
 ###################################################################################################
-SRC_URI = "https://vsdebugger.azureedge.net/vsdbg-16-0-20419-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV}"
+SRC_URI = "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-0-20419-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV}"
 
 SRC_URI[md5sum] = "0fe8523b5c637b0de6a890d78c171e87"
 SRC_URI[sha256sum] = "3cfb4b1fba86022926062c2e2ff77949912997f70938297fa558a90c0cb433cc"

--- a/recipes-devtools/vsdbg/vsdbg_16.2.10709.2_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.2.10709.2_arm.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2019
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-2-10709-2/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-2-10709-2/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "8e2497708884ba7efb2baf1423981a81"
 SRC_URI[source.sha256sum] = "67c3f3f4fcb1aa66c673f472de3f799269acac30cab48df66618f3dd58542f99"

--- a/recipes-devtools/vsdbg/vsdbg_16.2.10709.2_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.2.10709.2_x64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2019
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-2-10709-2/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-2-10709-2/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "ec95b4e673253661de89b9da526d49bc"
 SRC_URI[source.sha256sum] = "c78a82b235f7a6c24363e3efbf75aff9e5c454d0791e2117e54f40dc8f82a322"

--- a/recipes-devtools/vsdbg/vsdbg_16.3.10904.1_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.3.10904.1_arm.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2019
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-3-10904-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-3-10904-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "0e1063a309f836783e0fb8185f7a8e3a"
 SRC_URI[source.sha256sum] = "2efc3b21b78af294a2ed611434703902a074a90977003ba086a4203fbf44a3d0"

--- a/recipes-devtools/vsdbg/vsdbg_16.3.10904.1_arm64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.3.10904.1_arm64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2019
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-3-10904-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-3-10904-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "2e7c49c345a1524d3a25e944359d255c"
 SRC_URI[source.sha256sum] = "2d9e7a621aa8eaa4ed17c0d85b3d8b5c9684d3070e4eecbae02cb3545bdeeb00"

--- a/recipes-devtools/vsdbg/vsdbg_16.3.10904.1_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.3.10904.1_x64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2019
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-3-10904-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-3-10904-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "cc2fce5546e1b044cb65a18d6cec7f8c"
 SRC_URI[source.sha256sum] = "f3d71b167adad9a5c3f41e62a4f3af8c201977c3fda12180cdaf40af874e8533"

--- a/recipes-devtools/vsdbg/vsdbg_16.6.20415.1_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.6.20415.1_arm.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-6-20415-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-6-20415-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "e132a8ec5ba9b5d5618653970bc3705f"
 SRC_URI[source.sha256sum] = "75e206e29f8dbafb29cf52ee40c83534c436f607a4ee247a1734466b05e6ee91"

--- a/recipes-devtools/vsdbg/vsdbg_16.6.20415.1_arm64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.6.20415.1_arm64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-6-20415-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-6-20415-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "171ce77ccd743a45f4b87542db9949c2"
 SRC_URI[source.sha256sum] = "fdc3c923a6a8411fb2efe895185602c8f4e947b5188ed22cce62a2e75019776c"

--- a/recipes-devtools/vsdbg/vsdbg_16.6.20415.1_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.6.20415.1_x64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-6-20415-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-6-20415-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "5a21a41f5d835414699a58891aa483b5"
 SRC_URI[source.sha256sum] = "b520978bc4ff77d55cba94694a59a14027866bfceeaf715e99030ad6b02d6b66"

--- a/recipes-devtools/vsdbg/vsdbg_16.8.11005.1_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.8.11005.1_arm.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-8-11005-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-8-11005-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "f1d6aeb39c5f31df4aa745d30c269d3a"
 SRC_URI[source.sha256sum] = "38defa138e0b272c964693c572554f93a501471358a234946788fa0ed6719411"

--- a/recipes-devtools/vsdbg/vsdbg_16.8.11005.1_arm64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.8.11005.1_arm64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-8-11005-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-8-11005-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "f06a823821e161317151ed018eb38889"
 SRC_URI[source.sha256sum] = "06a2667497fa6602942e9ddb076ccceacc05baaeca326f7d0db346fbcec44e9b"

--- a/recipes-devtools/vsdbg/vsdbg_16.8.11005.1_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.8.11005.1_x64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-8-11005-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-8-11005-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "b4dbd2a4174d724d134f386f68e2abfc"
 SRC_URI[source.sha256sum] = "3540a9a0cbf2ff8ed74a31f4babbd71d47f44fc72b000aae140efc890d1f7257"

--- a/recipes-devtools/vsdbg/vsdbg_16.8.11013.1_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.8.11013.1_arm.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-8-11013-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-8-11013-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "28fc2de77461298762cc057ccab96b64"
 SRC_URI[source.sha256sum] = "b0a2daed3ce16867d400047da631acd9370fc182eea002682f2ed37aab089b6d"

--- a/recipes-devtools/vsdbg/vsdbg_16.8.11013.1_arm64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.8.11013.1_arm64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-8-11013-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-8-11013-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "9ce366a6a12216f758daea4b4d37d78f"
 SRC_URI[source.sha256sum] = "373f72d383f573e8920373e1296312f3e23e0a863f12390dbea209e3da363f62"

--- a/recipes-devtools/vsdbg/vsdbg_16.8.11013.1_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_16.8.11013.1_x64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-16-8-11013-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-16-8-11013-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "4631945941002d46cf76f7cd5d8347af"
 SRC_URI[source.sha256sum] = "bc13945dd27f17de5bfaf1bc530fae7e3b05479853ee71597a46bda7706a10a4"

--- a/recipes-devtools/vsdbg/vsdbg_17.0.10712.2_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_17.0.10712.2_arm.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-17-0-10712-2/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-17-0-10712-2/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "b7459ef8c6744cfb72d14a6ddac41f1d"
 SRC_URI[source.sha256sum] = "44545a24e2630d96f337d017380a91e3ade1ff3fa5f8a954ffb4b91481756796"

--- a/recipes-devtools/vsdbg/vsdbg_17.0.10712.2_arm64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_17.0.10712.2_arm64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-17-0-10712-2/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-17-0-10712-2/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "2e72fa52bf4ac6c35fb9a029fe5f42cc"
 SRC_URI[source.sha256sum] = "20a5f809b5e7dbe7c11b4d3fefac5b51c62866b1211b2ee7672b606ebe9cc87e"

--- a/recipes-devtools/vsdbg/vsdbg_17.0.10712.2_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_17.0.10712.2_x64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Richard Dunkley 2020
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-17-0-10712-2/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-17-0-10712-2/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "a6d00b871e5649d8f722c69814225e45"
 SRC_URI[source.sha256sum] = "dc31bba242615c2b160c6038e74b740568f23db3d3d0103aaf3a88cb35c48da8"

--- a/recipes-devtools/vsdbg/vsdbg_17.2.10518.1_arm.inc
+++ b/recipes-devtools/vsdbg/vsdbg_17.2.10518.1_arm.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Sequent Logic 2022
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-17-2-10518-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-17-2-10518-1/vsdbg-linux-arm.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "9e3eab533fec87bfb44d0bad4367082d"
 SRC_URI[source.sha256sum] = "ea42939a03883b0bec0ba92072a0a72ca6ca6134a445e8afe1f123a55b32b967"

--- a/recipes-devtools/vsdbg/vsdbg_17.2.10518.1_arm64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_17.2.10518.1_arm64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Sequent Logic 2022
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-17-2-10518-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-17-2-10518-1/vsdbg-linux-arm64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "3ac8735338b18d6f4f66c4b3f5846d26"
 SRC_URI[source.sha256sum] = "84dbdf48e5c906cdfc89284870b5c20d45bd56b1071baebb6e36eb13ee34356b"

--- a/recipes-devtools/vsdbg/vsdbg_17.2.10518.1_x64.inc
+++ b/recipes-devtools/vsdbg/vsdbg_17.2.10518.1_x64.inc
@@ -3,7 +3,7 @@
 # debugger from Microsoft.
 # Copyright Sequent Logic 2022
 ###################################################################################################
-SRC_URI += "https://vsdebugger.azureedge.net/vsdbg-17-2-10518-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
+SRC_URI += "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/vsdbg-17-2-10518-1/vsdbg-linux-x64.zip;subdir=vsdbg-${PV};name=source"
 
 SRC_URI[source.md5sum] = "538c54e6effac1a9f7bb92824c26cbd0"
 SRC_URI[source.sha256sum] = "eda05514bb72b30abf0478343bba787e912770fc6f7fc397ba619c9a50cc4b74"


### PR DESCRIPTION
- vsdbg downloads moved from https://vsdebugger.azureedge.net to https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net