### PR TITLE
Added .NET/ASP.NET 8.0.19, 8.0.20, 9.0.8 - 9.0.10 using meta_dotnet_c…

### DIFF
--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.0_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.0_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2023
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/6d3049cc-4dcf-4dfb-9444-009997fbe620/fa9da42c88a2d74aef7e99f56269e36d/aspnetcore-runtime-8.0.0-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.0/aspnetcore-runtime-8.0.0-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '5fd4f650217c8531bf5fba9b851462e52f3a04a71c4c1d7b48be6e22970cb06981d1b4fbbfdf2c8aa3662c9921a3c3d91d61ab19debcb5df046e87df1849abd6'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.0_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.0_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2023
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/91223e4e-2300-4e8e-9364-09ea1c317294/47fb26a2df5eeee08f77a4d1b720a34a/aspnetcore-runtime-8.0.0-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.0/aspnetcore-runtime-8.0.0-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'f9e1ae263dd944c70ea1818a3a44bb62aa5bfb65dafa463dc9f9a33bc8ad1c60b4e7a364a7414cc00a01ff707b5e88fc52c520edf0eb357ed1ddf4a8fcd8eae9'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.0_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.0_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2023
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/257bdcc7-cbfd-4680-964a-cbe8e9160bca/ac0cbf19d897ba51ae004b4146940a0a/aspnetcore-runtime-8.0.0-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.0/aspnetcore-runtime-8.0.0-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'c0aa3a926d6c2bc0d4cc14f5d7677a4592111bf3ebefa65c5273c4b979a6e2b5d58305a5aaf4ac78f593b46605ec02f40b610dcbff070b1d8cf8ddc656cac7dc'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.10_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.10_arm.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/50a67fd4-a5dd-42f1-a3ac-e008c3115dcc/816972da008ae5cee7612cad9b6808f0/aspnetcore-runtime-8.0.10-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.10/aspnetcore-runtime-8.0.10-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'fae8b6b270a4dc9218df99bb3cc10f0a52db9ed3630ba82056402154d27c238f76e44561f85348cf1a4f7e2bd1dbd910d4138a91ef66abe5685d9972b3d050aa'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.10_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.10_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/f93af34d-cde3-4231-a54f-119c328bd876/663b3c2dbf1ed2a3e08ac8e614060571/aspnetcore-runtime-8.0.10-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.10/aspnetcore-runtime-8.0.10-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '3a478f9310c748b7427c91deb3ba83f4c02557a7d7a3d7382526b6dc39dad3d938022475ab20f060f1b4ed365c7b1b95a1d089cca502a423298c41379bff8111'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.10_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.10_x64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/6d143cf6-e215-428e-bcde-9fd50ea0e1be/99652e31b3e0161a3f1f933e0bedf223/aspnetcore-runtime-8.0.10-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.10/aspnetcore-runtime-8.0.10-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '33221f19964ccb06cba74420dacbfe5bfd036f7847387093119f8f391d5716e1c5a8e05721f2335984409b43423d79b51ec571e51f0cdfae6d9d2a2b2d98505a'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.11_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.11_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/003f180b-e695-4094-bc3f-ef6473883d43/e861cb56edd58b05b03b5a92cf995f12/aspnetcore-runtime-8.0.11-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.11/aspnetcore-runtime-8.0.11-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '76645f129465346c5de7c543bea53829228a9912971c459ae48243317c73f47dec23d7b52d7d94ff3c701b8d2de651f3375deab38100f97be81f577c3b8cce1f'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.11_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.11_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/64a9f696-b039-4a73-b705-288fbf9c2e8f/c36bc24d6d359c019408b4f94ee67b59/aspnetcore-runtime-8.0.11-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.11/aspnetcore-runtime-8.0.11-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '75b5888b7d65cf9e971925e48962c0822f630390a3f0f04ce1d84546990fed312e8ae8513c82caeada145c2ac8de2b229fd1dad2d2df36c8e9db0df9f65595ac'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.11_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.11_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/6f89757c-3dde-4c3a-96a0-b04b1bde2c92/6a3591b360ed0f9d1118b97560b89625/aspnetcore-runtime-8.0.11-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.11/aspnetcore-runtime-8.0.11-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'e7acf9dc5cfa49aa7ec30dbb9586bc7beaac9e3116c75303b511770e3597b209739f28c754b2107c0255acac90187cd1000c1ee772463fc828934a4dda35f5c3'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.12_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.12_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/26fe9c15-40f6-4eb5-88fd-63d98eb259fa/c36789f8460b7e20371c38129d7fc160/aspnetcore-runtime-8.0.12-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.12/aspnetcore-runtime-8.0.12-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '144bd7d4502537a2806d17ee1612e4b3c262766c5d83da8b1031ca61f2a1eabd1bba5a531b1bfcafab999f084db961c9795804de651d87f81dd6d64976335948'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.12_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.12_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/8953c6fe-3542-4cee-b022-a50e029882a5/1bbce821b1ae97ed11b305dd708c0437/aspnetcore-runtime-8.0.12-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.12/aspnetcore-runtime-8.0.12-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '9323f6584bf98500fe023009dea5b90e49bbb34cdcea0868e8d18c2fe260b087315438ca2df783f259003c1a0ee31f2d735c8cea85c2c4fb04f6dafe05384531'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.12_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.12_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/df752f45-7e9f-4d13-8568-a88adda5aa04/9d59726fb38525b4956cbb1e1fe8a2c8/aspnetcore-runtime-8.0.12-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.12/aspnetcore-runtime-8.0.12-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '03a7fd37dce46c31d7e74da7cd4d9aabd82d5e087859d0065f470ebf7d0b62ad1feb59fc3f74690337a928f5751e04bcb7838896e64b3f8d25ae035c5b7f5c83'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.13_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.13_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/2c764efa-2f8b-44d1-9308-87dcafaeff2f/cd8f6383aa8adb1dd9493520b57f08ef/aspnetcore-runtime-8.0.13-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.13/aspnetcore-runtime-8.0.13-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'de5a3dcfabaa7f01aaffb78b2156d9d79d614f0e52ebe619657072568ab0fc47f4d53e7b577a7622392502cd3a739400af6c26999247cc50c29813b6a94cfcd0'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.13_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.13_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/3167f98c-e2ef-4d19-bd00-178c27ed7f3d/8f9eb25b9899009f11ae837612b52c0e/aspnetcore-runtime-8.0.13-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.13/aspnetcore-runtime-8.0.13-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'd67130310e81f727f1d4806463f49af18e012d6dc766c940838854922b3a3e7f7171c87d595c4dc09e1c63470fae3017b54d51be98618985129ff37d6a5ac0b3'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.13_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.13_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/2115caf0-c47f-448a-8ad6-107a742d2b9e/52036588ffe8f8abd87a3d033fd93b67/aspnetcore-runtime-8.0.13-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.13/aspnetcore-runtime-8.0.13-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '7b21aff45c3ca7ccdc0527c6de05c209d58a56a15cf10e656522261f884cf272a92be13696b1a0f1ae2baaa0d825ffda58d954871a17b3c3a8659a9f3a36c7e6'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.14_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.14_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/8e39953f-874d-4d34-a41d-2f0f761d9657/0ecb320781f83fb3a94620e1dae6fe27/aspnetcore-runtime-8.0.14-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.14/aspnetcore-runtime-8.0.14-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '179401d8de13e20e4e79fccc29d604766e52d5c173290aef1399e4199bb27f29f66c5ee4cbab2c1f446808d40fcaf93fb416a04368b6387741656053e40525f0'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.14_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.14_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/c7cf0f96-e75f-4376-9f4b-fb10b2129d0b/a0eeda2100a9fd1858b95c8d9267fa51/aspnetcore-runtime-8.0.14-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.14/aspnetcore-runtime-8.0.14-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '64c2247ca84cce13525e54e2eb062ca25d7f8435b54543442b11673906ee998b147321ae720920deb8ed96f66c1ee917c7bea9b90b360108e045384e8da44923'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.14_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.14_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/b901af61-a4e5-41db-9402-f6a035bf3ffc/af3e800d44ced22133fd88f8b7bc4ac0/aspnetcore-runtime-8.0.14-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.14/aspnetcore-runtime-8.0.14-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'b8cd0640c2a7382330b44be3130327ff0036be87b620f9b8ae5b854fce346b60586dd7bba6a684d7b051dc934025170cb945c41ea3bc92115b30e67eeeafb920'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.19.bb
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.19.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 8.0.19 ASP .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/aspnet-core/aspnet-core_8.0.19.inc
+require recipes-runtime/aspnet-core/aspnet-core_8.x.x.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.19.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.19.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's ASP .NET 8.0.19"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/8.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/aspnet-core/aspnet-core_8.0.19_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.19_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.19_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.19 of the ARM ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.19/aspnetcore-runtime-8.0.19-linux-arm.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '6b4afe7dce6ab2e7062cb485c46126dce9cfdb0003721e0d8886ccfaa9a6deec3eebaf8a4de69ebe49463940c6c8ef5addc4512d9c2263d81710b934f41b91e8'
+
+SRC_URI[md5sum] = "6361bc3ba753dc156985b92bb4ea4b92"
+SRC_URI[sha256sum] = "5d8ae9e0b2bf4d3482367b251d8d58d966cc93e8a2c3a3e933a2de2d2ca6a38b"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.19_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.19_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.19 of the ARM64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.19/aspnetcore-runtime-8.0.19-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is 'cc14503e5c1d94a333fd8048f628760f6df2b2acd4e0d5ef465cbbfcc13517753d6fd5b1d5fe4b38b07704418a713e1338005453a7cbb8fb3f300760d00fc6e6'
+
+SRC_URI[md5sum] = "a475dd82f5489564efb0f6ccecd0e68b"
+SRC_URI[sha256sum] = "bf72039478ca501546ed0e252289677cdbd96b9c7342b3c83d398ac332424b52"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.19_none.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.19_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.19_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.19_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.19 of the X64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.19/aspnetcore-runtime-8.0.19-linux-x64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '9503fe84627716cb9df02c648e34971c6ec4d44686f213bc6f6bd74bc54ffb41ef272fbd2c8aa3f0a309b20664796c12f9c77b137015f84581ac265af2f21687'
+
+SRC_URI[md5sum] = "843eb643bea394dd962e2cc43e21884d"
+SRC_URI[sha256sum] = "b004aaf0a463dfb6c9c0c2510c842dce56d0b50b04bdc8dad34e86bb8b4b06ea"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.1_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.1_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/6d73b0dc-fd8a-4f4a-9b16-bf075c2985e0/345ca37b7db49d9528406707aa97ff6c/aspnetcore-runtime-8.0.1-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.1/aspnetcore-runtime-8.0.1-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '1865185af78ee742588187f4a3e98aa30e1bc5da0180512e5fb6e40274c68a45052bc06d357f8541b6fa2bc6d4855efe4b45f706a48230da8a4b4078ca2a21c1'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.1_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.1_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/0688a08e-fdaf-489b-90e4-033cc19cfffc/c9a9c648862b0b18c9aca77d3be0ef9f/aspnetcore-runtime-8.0.1-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.1/aspnetcore-runtime-8.0.1-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '7d34b6986363e54dca53828ca7a4d658aae1b24f8f33c6a82f811e12ce6d56698462db746d9f19e4ad245cc8d130a19930be28e0a0c2da2c96fd74b1cb2d8192'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.1_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.1_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/8e19b03a-93be-43ae-8cd6-95b89a849572/facbb896d726a2496dd23bcecb28c9e9/aspnetcore-runtime-8.0.1-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.1/aspnetcore-runtime-8.0.1-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '64eecc0fc50f8c68205123355c43eae5ee29b7f6061a260315818960153fdf25f2bb25a51dd3f051e2362e228c032f2d0b9e7b6b476ac52141c17cfd8de0bfd2'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.20.bb
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.20.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 8.0.20 ASP .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/aspnet-core/aspnet-core_8.0.20.inc
+require recipes-runtime/aspnet-core/aspnet-core_8.x.x.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.20.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.20.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's ASP .NET 8.0.20"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/8.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/aspnet-core/aspnet-core_8.0.20_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.20_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.20_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.20 of the ARM ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.20/aspnetcore-runtime-8.0.20-linux-arm.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '188dd1f2c4ebe8932aa325489d019236561d2219248b7f36801609b423ceccf6b5b6ffaf0ed365fb19b2da0b54378b5145d9e87af5cd95fa46fa7c595f3cbe42'
+
+SRC_URI[md5sum] = "b3cd5313241470b9d4dec9a2c14d3763"
+SRC_URI[sha256sum] = "9027c5112a30e40c9926cde7337ae5c10f231e388d1191bd20ca618f8afd87ff"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.20_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.20_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.20 of the ARM64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.20/aspnetcore-runtime-8.0.20-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '17b01d6309899eea40200fc449cb606df5541c5802b973c21e71d7f5539b72cb35e2daf38bd9e17ec6dccfb23c3c17afdb1e7f05fb13f10701561d2e00b19645'
+
+SRC_URI[md5sum] = "63e75d4f06c4068aadc0507fb3581797"
+SRC_URI[sha256sum] = "eceeb83b41370463a94dc69941f3a5d84e8b4eee635129c990a27eddd2ba2cd4"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.20_none.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.20_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.20_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.20_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.20 of the X64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.20/aspnetcore-runtime-8.0.20-linux-x64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '228713f3c3600c49e7924e26dc86115c9674b5308b44514a53f670fa785038aa885ead8cd2c1c1850d1565b689a95a92e97f472d86429930dbfb114aa6020eb7'
+
+SRC_URI[md5sum] = "2e546c27576838a0ed27ac784c0a4732"
+SRC_URI[sha256sum] = "58490d1f153c78f7c01ec6fe9354099eac0a0dc0e72f806b41b9cdb44b9aea32"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.21.bb
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.21.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 8.0.21 ASP .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/aspnet-core/aspnet-core_8.0.21.inc
+require recipes-runtime/aspnet-core/aspnet-core_8.x.x.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.21.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.21.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's ASP .NET 8.0.21"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/8.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/aspnet-core/aspnet-core_8.0.21_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.21_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.21_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.21 of the ARM ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.21/aspnetcore-runtime-8.0.21-linux-arm.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '18623bf73f2236be293d7456b6b19d0bdafbf41971d42e8d4b86fa5369e9335132436672e656f6307aab59842bb1a22e447361d77a18da59b7b70f1008db0b9d'
+
+SRC_URI[md5sum] = "f7448090f4af99db6c102d28dc7d256b"
+SRC_URI[sha256sum] = "2ce75146385e7964c6fd11f9775455ab802c700541be3acaecf74b43191502e8"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.21_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.21_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.21 of the ARM64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.21/aspnetcore-runtime-8.0.21-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is 'db04b085c4ce1d732e55be57efe771b4be4c6bcf9b5359fbf88993b19026d77e7e108a41ab0c447da100306df8dfde90bc9c206cefb1856f7da6b618b6ceda32'
+
+SRC_URI[md5sum] = "0d8b03eefdb178b45874ac4aa659a2e4"
+SRC_URI[sha256sum] = "87dc5e4a8573000c9fe89d6e2971c09fed063ce90172fc8b5f5fc704a56ad81b"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.21_none.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.21_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.21_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.21_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.21 of the X64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.21/aspnetcore-runtime-8.0.21-linux-x64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '4aa9458d3de7b4ff960adcc4a655e4d7e4e6570e97791919113b8c9a55883964a60241daf3a70c60494cde1a61155d802339ec03b046466eac67298f0acc7289'
+
+SRC_URI[md5sum] = "653cb67e85379e1fa52950d19ac05805"
+SRC_URI[sha256sum] = "08415698df9a1c0d217a69e47f1578b458d2ae3bb4677e0281fadd0209f3745b"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.2_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.2_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/272dbea2-057e-4032-9857-7e00b476ceec/3c472df94b1c3f5e0d009cbccc9256a6/aspnetcore-runtime-8.0.2-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.2/aspnetcore-runtime-8.0.2-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '427e60fb1ed636ed6c8b8be22b125019f0cf8cad3ab07bfc362d56a05f12206eaf245c8003b5a1c1b342c65d703f3f401982aaab92f86de5d73650f742a2fdba'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.2_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.2_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/bdfd0216-539e-4dfd-81ea-1b7a77dda929/59a62884bdb8684ef0e4f434eaea0ca3/aspnetcore-runtime-8.0.2-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.2/aspnetcore-runtime-8.0.2-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '9e5733a0d40705df17a1c96025783fd2544ad344ac98525f9d11947ea6ef632a23b0d2bf536314e4aeda8ae9c0f65b8f8feee184e1a1aabfda30059f59b1b9a6'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.2_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.2_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/d6d79cc3-df2f-4680-96ff-a7198f461139/df025000eaf5beb85d9137274a8c53ea/aspnetcore-runtime-8.0.2-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.2/aspnetcore-runtime-8.0.2-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'c8d4f9ad45cc97570ac607c0d14064da6c1215ef864afd73688ec7470af774f80504a937cbb5aadbb0083250122aae361770d2bca68f30ac7b62b4717bee6fca'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.3_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.3_arm.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/16463b95-fb59-4769-86ed-d57012b2da25/d7f5df1e4b840ebc8d001d01b8cfdad5/aspnetcore-runtime-8.0.3-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.3/aspnetcore-runtime-8.0.3-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'a7853f77615d37151fd59dfd4916fc7794bc4d83b0cbced85b857f501dcd883ec681b303e8d2fac438e06a9e90f4cee9f68aede64d59b033d2f08144839a04af'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.3_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.3_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/9feb7c60-3821-433f-994d-c6861b341d3b/5b90405a9978455b10ce6f1fc058fc1a/aspnetcore-runtime-8.0.3-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.3/aspnetcore-runtime-8.0.3-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '2ddf440be273febae8049df9b2837fe9b9d95d43a31898b915dbf39aedaf15a291ff28711e983fe099ab22a291ad244813256d57ebb6ef1fb94f04d712a96435'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.3_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.3_x64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/c1371dc2-eed2-47be-9af3-ae060dbe3c7d/bd509e0a87629764ed47608466d183e6/aspnetcore-runtime-8.0.3-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.3/aspnetcore-runtime-8.0.3-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '73a16e08402989f25ca780acc981c2ae3a41ef39b4bb6b6b4962053144b6eda7c175fdd5ee3c25bcd0c86a27d1a83d4f8b9b2f69f37d4e3972f5901a9e0600b6'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.4_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.4_arm.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/f12a9449-04ba-454c-bc35-4cdb426accf6/2729a371b61d59794845eb309a46fba2/aspnetcore-runtime-8.0.4-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.4/aspnetcore-runtime-8.0.4-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'f9fb78800e47e72498472decb7dc32bf3a22ed4b8b4706e381c86f17d70492d80e2946c4c28e6138aff3b9e9eaeffb6d78a0a856723580d0497abc0e2b4f7e28'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.4_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.4_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/80ec12e5-b26f-466c-a20c-f96772ea709d/606e7203912400b44cb35d6fcecf60bf/aspnetcore-runtime-8.0.4-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.4/aspnetcore-runtime-8.0.4-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '0b0b3dffe678211afcaeca5d7e381f2218f156421c79dd06e083b1abd92ceb2b5c04c8a159b7d67b866393b8169de826ede70240226e0164451b329b7d46b570'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.4_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.4_x64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/0b0bc7f4-c6e5-4cec-a7ed-45c2fac0da4b/ae2090564274152b5a4be9f1e66c5d30/aspnetcore-runtime-8.0.4-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.4/aspnetcore-runtime-8.0.4-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '8ab281977116bf59a672afe5463bce4433378cc8a67d332c564a012939b7dbdd8756df82a115a5ab93f8186c22700a6dc0272b99a0f484db837da96820c78e79'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.5_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.5_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/4a8e69b4-5f79-4b86-b922-5b431ff02736/db7eb177e07a80137aba9abaaf3246be/aspnetcore-runtime-8.0.5-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.5/aspnetcore-runtime-8.0.5-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'f648c58794f217ac6faaaf67c17370658445655827d720335e38762541fec808d79aee0f87d0e27a6d3bb525c5a9ebcd3d94243190e7a5c126489f1840cd5373'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.5_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.5_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/208a57a8-fcc0-4801-a337-79095304d2af/d1ffa79af24735af4bd748229778c1a9/aspnetcore-runtime-8.0.5-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.5/aspnetcore-runtime-8.0.5-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '54ad859a3307a4ccce6aa794df20dab3fc38cb4a8fc9f1c2cb41636d6d19fed1e82f88a0099bdc9f30e08c919ae5653da828ae54b0299291dafcc755575f02db'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.5_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.5_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/ccccfeb7-0af4-4713-b4f1-cf49b5c8bd6c/5b04c0188dfcf78b70da78ae3bd7f3ab/aspnetcore-runtime-8.0.5-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.5/aspnetcore-runtime-8.0.5-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'ffe6a534ed7dffe031e7d687b153f09a743792fad6ddcdf70fcbdbe4564462d5db71a8c9eb52036b817192386ef6a8fc574d995e0cdf572226302e797a6581c4'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.6_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.6_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/c27a9707-8627-43d3-837e-fa144bab2984/40f243e656752b87ff033e568d49b510/aspnetcore-runtime-8.0.6-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.6/aspnetcore-runtime-8.0.6-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'bc1ee3f85799038e14dc2b28a57ea367b0d837a778add03a23804595156ae333714fa54a13503b173412c082043e6212035fe6238d0914372491e09efb09de62'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.6_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.6_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/ccdcbb70-a5e9-4753-b6e3-4461ce56a69d/240803fc1ffba38ab3603778c03e9b87/aspnetcore-runtime-8.0.6-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.6/aspnetcore-runtime-8.0.6-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '9ed12847e404a0a4fdd8fca33a9a787c5ac2e6745d23821c7890f731f2f8f5682e7f9166b2764b13b612b08e091c71e13359b68acc11bcf990afdef1d42f6473'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.6_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.6_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/ce31d92b-b514-4f9c-843b-29c466871369/b332eba5641cbc6eed1e3a98480972d2/aspnetcore-runtime-8.0.6-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.6/aspnetcore-runtime-8.0.6-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '16cd54c431d80710a06037f8ea593e04764a80cbaad75e1db4225fbe3e7fce4c4d279f40757b9811e1c092436d2a1ca3be64c74cb190ebf78418a9865992ad12'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.7_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.7_arm.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/d37fc703-70c6-46f2-a5a1-b60f45fd71d0/6a74aa0bb89feb7f795df1ea92d030bf/aspnetcore-runtime-8.0.7-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.7/aspnetcore-runtime-8.0.7-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'd0107441223a44f1c4d9fa08c2d66b1875d20917fb1dacab7f80a42f0da1428570dd1cb86bc1f6e4eef3414e1770768fc8f17b836d0f7ab9b890848bc18ce8b0'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.7_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.7_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/421d499f-85cb-43dd-97b2-8ebfd06dda8a/61b03be4662125e4af044c7881e66f0e/aspnetcore-runtime-8.0.7-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.7/aspnetcore-runtime-8.0.7-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '5f1d31b0efc793655abf4289f8f1c7e8cd1ffabfd65b385b49e3f5232277c62ccfbbdad2a51731a8a88594a06c2c9774e38865cb3f7e19c9925a12b25b40b485'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.7_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.7_x64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/06cbb934-ef54-4627-8848-a24a879f2130/52d4247944cee754ec8f4fd617d502a6/aspnetcore-runtime-8.0.7-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.7/aspnetcore-runtime-8.0.7-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'c7479dc008fce77c2bfcaa1ac1c9fe6f64ef7e59609fff6707da14975aade73e3cb22b97f2b3922a2642fa8d843a3caf714ab3a2b357abeda486b9d0f8bebb18'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.8_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.8_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/26f16795-9928-4ddd-96f4-666e6e256715/bf797e4f997c965aeb0183b467fcf71a/aspnetcore-runtime-8.0.8-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.8/aspnetcore-runtime-8.0.8-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'd0feedd91bb4028069d8cff1726191e9f09920e756405de0d2bbf6f43116277cc93ebe2483f405baa4972b54ffe89b09cbe172a639e60397ae7138df5ef48c4e'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.8_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.8_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/f6fcf2c9-39ad-49c7-80b5-92306309e796/3cac9217f55528cb60c95702ba92d78b/aspnetcore-runtime-8.0.8-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.8/aspnetcore-runtime-8.0.8-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'c3dc9d71fca0a48eda96074cbcef4c9a265c1c4e10cbff38614dd74d79443ae9d1ccd10714764cd041291f81d83c0ed1c307abf89249ab4b6f58a5de952fcffd'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_8.0.8_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_8.0.8_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/648de803-0b0c-46bc-9601-42a94dae0b41/241fd17cee8d473a78675e30681979bb/aspnetcore-runtime-8.0.8-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.8/aspnetcore-runtime-8.0.8-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'd6c0cc2aac79fbacbf81b597f286763599f66278c17ddb448ce0b93d499bad8f88777d425854e68602945ab18af8a61f1ee59d431d5503006137f86113faa8b2'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.0_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.0_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/84aa8e86-c6a1-4562-84f3-828e836ef26c/96772a224b9ff3be8904b63f37d7cf63/aspnetcore-runtime-9.0.0-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'f711af1fd17f6976d98609feba32dbc8b027e3b851439ab0d5a68082ba6fa87ee3888cfd8cdd368b90fc3b3710220be2de9864ab50297e3797adc4bcbaab7e99'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.0_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.0_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/b2029a3e-c67e-4905-ad1f-08b164322520/bd68ea0b77f12df21b935da338fdaf25/aspnetcore-runtime-9.0.0-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'd5df4b549a59c8b9b2bcee5e0ffa9fde81fc3df74b299ab49820af6bc0ccfb89eec3714ea558ffcdd2a16821a4d1ecdcc64e9981804978ee3ff1d444b8125681'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.0_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.0_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/e4791376-b70d-431f-bd98-5397c876b946/64ffc29a4edc8fd70b151c2963b38b09/aspnetcore-runtime-9.0.0-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '1a81023f119dd5e5b0f9d87b0e3c42df89824b9fcb73192a4670cc2c67358cd018a7c9c965245c7883de468bda88c81d64a21c60f9bc68a6559d76f32d34ce96'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.10.bb
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.10.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 9.0.10 ASP .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/aspnet-core/aspnet-core_9.0.10.inc
+require recipes-runtime/aspnet-core/aspnet-core_9.x.x.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.10.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.10.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's ASP .NET 9.0.10"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/9.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/aspnet-core/aspnet-core_9.0.10_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.10_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.10_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.10 of the ARM ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.10/aspnetcore-runtime-9.0.10-linux-arm.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '0eb272108293cf57b76808d63334e985177f09a695d08fae817748cb48aec5d8ac37e08dc6cc7dc08a2ca090d3f29886e3dfc7abf2ec0718fd48215887142c6e'
+
+SRC_URI[md5sum] = "23ff1cb3127f366fd95367fce7a4d8b7"
+SRC_URI[sha256sum] = "bdb26d093dbfb60772eefa6c9ff16da30acd791bb1f510dac0c48a10ec5ceb94"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.10_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.10_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.10 of the ARM64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.10/aspnetcore-runtime-9.0.10-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is 'ef2696a1b8080312e87af8bf1335971a49a0b7d074b0a6276473e58e5460ecb55d1908413d34d3265c6dd5cfc8c1c60ab04fcb509c940b20e61ea5ae49d04926'
+
+SRC_URI[md5sum] = "bff285ce61b92398b68829435e68f99d"
+SRC_URI[sha256sum] = "e7e06ffc3711f4b2bf30813b6c1717055d20ca82ee042fa9bf05a5a0bcd4a7e3"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.10_none.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.10_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.10_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.10_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.10 of the X64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.10/aspnetcore-runtime-9.0.10-linux-x64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is 'ba1b184f3bc1c7d423186240fa30e4acd0b8392e8c61b7b593b8d12f8accc65dccfcd4120d9b9ec25c3a278df4fbaf324ff2cf1b8d3997a24417eb2abb2d8043'
+
+SRC_URI[md5sum] = "9552a076eb9cb77039cb5754662770a6"
+SRC_URI[sha256sum] = "7fd7fd9da1259212c9423d561b059fa45b21bcbcc8e94da15dcca9fa73d71984"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.3_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.3_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/ce50fb55-0885-4427-8636-74a4be7a62b0/88b3a34f6713ba012258bc43c8f6fb2b/aspnetcore-runtime-9.0.3-linux-arm.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.3/aspnetcore-runtime-9.0.3-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '2a7508de9795d8238a1d4ff7e74df819538ca47d6ff8663ddb27b5f7514dcf487e7eed22d8c84258cad3fb30066621a6c79e08f3b060f15d64e85145b376aef0'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.3_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.3_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/3ad17a72-66ec-41fc-b771-8094284b066d/ebf2d0da156c97776e9d27ad699d96ff/aspnetcore-runtime-9.0.3-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.3/aspnetcore-runtime-9.0.3-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '8a027078b46b6ebb3f4beda2b3f3cf7960701b71b9f2b6704c17f2752279c764755cadfd30f3e2f3e3ab26869e50a35c567c2fbd41fd98d77ae2f6fecde18b50'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.3_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.3_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/30d54f5c-f3c6-4ee3-bdef-75e7cb0a40c2/cdb0ba537467777ff193f8f3cae6fc76/aspnetcore-runtime-9.0.3-linux-x64.tar.gz;subdir=aspnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.3/aspnetcore-runtime-9.0.3-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '38a3b73a6c41ee6f67e9108ebf684ec082fc6dfaa941ea225f6eb200a1e34909c05fa47a087c35c18eab607350796ecd16c09f2e3774dba590083c93742e39a3'
 

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.8.bb
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.8.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 9.0.8 ASP .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/aspnet-core/aspnet-core_9.0.8.inc
+require recipes-runtime/aspnet-core/aspnet-core_9.x.x.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.8.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.8.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's ASP .NET 9.0.8"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/9.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/aspnet-core/aspnet-core_9.0.8_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.8_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.8_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.8 of the ARM ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.8/aspnetcore-runtime-9.0.8-linux-arm.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is 'a99444b1cba7af4acd12d9ad4126fe4acddf2ef0e02b999de0bc1853742e136effb03ed7adc2a0a47062d0051b3179320a47fd3d239d0fb86f9775b73de43d1a'
+
+SRC_URI[md5sum] = "13bbdec4de92a9baacf98d85c400c0bc"
+SRC_URI[sha256sum] = "07ae27876aa6eaa37e49cb1671f50691278521816dc698724d711fad63b7870d"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.8_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.8_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.8 of the ARM64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.8/aspnetcore-runtime-9.0.8-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is 'cf1e72f4b327b93c1ac3f2def9ca83bee27a408e5b5913f84ed954cfd6c4639da1664fe3f4e3925883db77ed29fa5364b9ca8af3796f33ca73a4cb7484e326bc'
+
+SRC_URI[md5sum] = "ec97336f25413df1407925fb96ad39af"
+SRC_URI[sha256sum] = "a07f4da140de29e47518d78a7f83249d647920103f7c2fdad2e48c25afc86611"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.8_none.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.8_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.8_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.8_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.8 of the X64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.8/aspnetcore-runtime-9.0.8-linux-x64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '08afdf924d00f875b44cc4eff68b55fb9b63e4cc68e6b5cde873da2bce9c5b5f4120e869b6a1dfdea4ab104ab0ac8783ef1577b4d3275aae899a53cd88130f1d'
+
+SRC_URI[md5sum] = "bf6ccba53a23a30f0b9292d5f696fdb8"
+SRC_URI[sha256sum] = "4b0fdc3f5281d9f3223158b145f7a17ac2b53a008d9bf1028b886fe893a7165b"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.9.bb
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.9.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 9.0.9 ASP .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/aspnet-core/aspnet-core_9.0.9.inc
+require recipes-runtime/aspnet-core/aspnet-core_9.x.x.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.9.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.9.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's ASP .NET 9.0.9"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/9.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/aspnet-core/aspnet-core_9.0.9_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.9_arm.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.9_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.9 of the ARM ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.9/aspnetcore-runtime-9.0.9-linux-arm.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is 'de2a52ea4a9b872adbe21709d6e1d88731e42057037b826f93db9c98b0ee8d10eb3159fbdc8421345f297cfa35d692a736be65e16454db2e4d340b3bb928cce1'
+
+SRC_URI[md5sum] = "55a6d8c0a94457b9207483e8c248d915"
+SRC_URI[sha256sum] = "897fca4b2087e4a858cd1a4446d1820fde14360febd2518c4da7e37a4ba5e300"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.9_arm64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.9_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.9 of the ARM64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.9/aspnetcore-runtime-9.0.9-linux-arm64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is 'cd2d24e16edfdbd34287a4ae25e0a517aaf1bbfa0ffd4d3bc7eac63d85dd544d43b12d081aa2419af13ac27fdb524f918ecf2fdfa916039aed66d502318a72ee'
+
+SRC_URI[md5sum] = "36237a4eea71d0c3eda1041fba4df0d0"
+SRC_URI[sha256sum] = "8ad2cd0513407d84a52466df3f5dee15a72727be95747e6c59f3af6afb71879e"
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.9_none.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.9_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/aspnet-core/aspnet-core_9.0.9_x64.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_9.0.9_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.9 of the X64 ASP .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.9/aspnetcore-runtime-9.0.9-linux-x64.tar.gz;subdir=aspnet-${PV}"
+
+# SHA-512 hash is '7ff1b517c45b2c7720fc1be808842c5b7f644ff9138f221862620e23660db528b5961f791434aa75885c808ecb3bf9d213a33e8ff3eaa477df7d6256d215a6c4'
+
+SRC_URI[md5sum] = "cdfa9a69eeacb0281ee3bda7bed60f71"
+SRC_URI[sha256sum] = "48b06c19c496d87d446655185aa14551393ac33a40f7154947595ba03ff308e1"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.0_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.0_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2023
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/ee0a9245-5b87-4217-a9a5-dc589187612e/f3631cfe19cb713296314a6028a9e856/dotnet-runtime-8.0.0-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.0/dotnet-runtime-8.0.0-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '2dd820ae2341b00844430bdfa3d45631b080d69aa2e55c89ab034a46e8712c542428267e10a5077bca607aa0c58e1efd42422cba4d76c2eaabf2ead87874ce24'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.0_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.0_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2023
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/c879318f-48f3-4cc4-8dcc-a6b77cfdfc38/7890f8a96ea335f5265cd1aa80cac8ce/dotnet-runtime-8.0.0-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.0/dotnet-runtime-8.0.0-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'bb39fed4cff3a1a0a4e5084a517feeacb571700b8114b83b0b040f63f279d32eb9195d9b94cd60f8aa969b84adaad51694a2e26255177a30f40f50f634d29c21'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.0_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.0_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2023
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/fc4b4447-45f2-4fd2-899a-77eb1aed7792/6fd52c0c61f064ddc7fe7684e841f491/dotnet-runtime-8.0.0-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.0/dotnet-runtime-8.0.0-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '16a93af328bcf61775875f4007c23081e2cb7aa8e2fba724aea6a61bc7ecf7466cc368121b08b58ac3b72f68cb67801c68c6505591eb35f18461db856bb08b37'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.10_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.10_arm.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/3f8dea7e-13bf-4931-b11e-77fcc6de7ca9/37531adc6a054037c064c47dae4e7f77/dotnet-runtime-8.0.10-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.10/dotnet-runtime-8.0.10-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'f06b8787e4f86f61569959228a9ae7d10bb7a1fa967010d7f3ca0080c850513cf5657c18d472211ce16880ff5eafc6c8442a564b2f8351d77c5dd270213c984c'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.10_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.10_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/6c71a005-d902-4df5-8cbb-f1fd53cf14f7/658dd2a2a839c14173e3804befec6a7e/dotnet-runtime-8.0.10-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.10/dotnet-runtime-8.0.10-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '31599ffbca710247f4e03fe99b1098b287a0ed820a944b5a6ed22372651c97d67531c34abadbc52e59e8f70b4f76cd331221d008684f3feefd9be2904a73e388'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.10_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.10_x64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/ebc433c4-8f01-43c8-a1e2-bbe1291ba857/e073f3f679d7a4067a56e8f5d12fc0e5/dotnet-runtime-8.0.10-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.10/dotnet-runtime-8.0.10-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '7fb813677720d125c2337fedc6131b230daf1c1d79d5912a1ca6b5e08bf7802b412de3248d645b6483ab23f3fae837ed02a0e520e33020cfef2c888c54f474ac'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.11_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.11_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/b4d8f2f3-a0fd-4d48-b584-cae2c3af5c06/97479f98b5746e515d7d99f72b67c852/dotnet-runtime-8.0.11-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.11/dotnet-runtime-8.0.11-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '279b93bf6b5c5c2f45427b620c56bff0e22ec8f3fb9a4f3749e7a6a0d0d0ee8163851b5bd081c6814b758068df7ba1b9401c844ba5905b27a830020846ef6406'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.11_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.11_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/501c5677-1a80-4232-9223-2c1ad336a304/867b5afc628837835a409cf4f465211d/dotnet-runtime-8.0.11-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.11/dotnet-runtime-8.0.11-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'f27d66dcdd249a6a2f87241b460238960240d163ffc081d8e7b42bd62702079f1a6784e3503dbd4ea8f9e816d82142fc829c759cbf9a1682b0340f0cebe16db5'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.11_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.11_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/805cdca8-ac43-4d76-8ce8-efd11f1997f2/17aeb8b0cd34c6f8d80217bf6a4ed3cd/dotnet-runtime-8.0.11-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.11/dotnet-runtime-8.0.11-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '71ea528900c6fc7b54e951622296421d2a96191870c47e937117b84b28f91bf407d02046ddfecfe4ac37dc6182c65d1940927c33e45fa3d6f0179f81692490d6'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.12_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.12_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/a50c2f56-3ee5-4387-a9a7-4338b75fb5c9/41676fb7ec43d9108a65fc0d76c15717/dotnet-runtime-8.0.12-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.12/dotnet-runtime-8.0.12-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '0b8e3c37f205cf965afbd7096afd5fc6e202248b3e3c174712e1bcf34b6b64ab7b0ef866eeb6e16a114367e35666dacb52eb0ba10dde8b3143314a051eb1a1d0'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.12_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.12_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/4bfa2e49-fd4b-4aa7-b5c7-cd344beb72e8/d04a3458f047737f9343430e901efadb/dotnet-runtime-8.0.12-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.12/dotnet-runtime-8.0.12-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'c300a87e41798fae7ae4920c140bbe3499a1093d418450f9bfa469b045ebe2e5840d95487e937eedbe8ab221e1388aed76fdcc18c92d81778ee43383ba7fe33b'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.12_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.12_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/14263fc6-1fdc-46cb-b692-df3e0f4204d0/24c37267d4f4e166df57ea3ec9acff18/dotnet-runtime-8.0.12-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.12/dotnet-runtime-8.0.12-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'e0d216d54e9a21aaefc120a481050f1137cc708cbbd17204f0b1a47dbb6424078e8b44dc842957a6691025cda1490e5061092802484b5fd12c5903f5ba634481'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.13_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.13_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/e42f6ab0-c3df-46db-83dc-47205f5cb6fd/0c1cf07866e0674a18748cfed2b747b2/dotnet-runtime-8.0.13-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.13/dotnet-runtime-8.0.13-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '5d018fb50eea96f3e9a56142202ccb1c73a725219d7257b0debbeef3ef196c69b076b98dfb6f098818c0514084df33f6704bc13a478d1727b012d6ba9eea0492'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.13_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.13_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/7613adb2-d77c-40ac-b9b4-28f0f571489c/0943d0483052418201c63456b52a1908/dotnet-runtime-8.0.13-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.13/dotnet-runtime-8.0.13-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'e6c42ac1758239405c8a740194023b4ade1017def3bf330557dc16312b2f40599be30a8bfc8db05559649cf0eda5fc43af153320f5378dcb4872af13679bce8b'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.13_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.13_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Sequent Logic, LLC 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/d26516b7-7049-4c18-974c-467190461f3a/667fb6101ef1f43f624e175b49f8ab49/dotnet-runtime-8.0.13-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.13/dotnet-runtime-8.0.13-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '8649eda14e8bc993f8cb3d421d44a4abb218acf29996ac1ec939686bf657e75b60f2b690180a4654ee15ebb7b95386eabc969ea98209e31e2801620ff90fce43'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.14_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.14_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/c3eae65b-60c5-4f4c-b466-e2671fa9e044/ca57cc875f7991917e6542fa404e94a9/dotnet-runtime-8.0.14-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.14/dotnet-runtime-8.0.14-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '6bbb0ef4d8857ebb9bd9710fce985af61ef0494ae7949ec2b01d8951b15306bcb9ec4e8e45ead8013828dfa92e9394d6beb01ad5fc4c6ae2a3fb9916476b1661'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.14_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.14_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/0e0083e7-0829-4d6b-ae47-6954508bb545/47c8c96704206348f8aced67d9f5552b/dotnet-runtime-8.0.14-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.14/dotnet-runtime-8.0.14-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '519b6d0a613b1ad3f76cd8316c29dcf4a94f605e3685ffa979cc632b32666cc9b37a08a84a8f9b22dba8bd63112e5c65386ce4b75a8f8df50c528c3a1a395295'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.14_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.14_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/a52595b3-f025-4bcd-a3fe-b6091e276d76/4c0d27fd34b79bf7c21ba401b84c76e4/dotnet-runtime-8.0.14-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.14/dotnet-runtime-8.0.14-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '5b7c7300dd30084650a2265b6618f366f099dff2b292482e5e05f14f3a0b0850c658ecf383683e1dce4e753a616fd2e3c169c1734a679afcc4c0cad488b9f8a0'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.19.bb
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.19.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 8.0.19 .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/dotnet-core/dotnet-core_8.0.19.inc
+require recipes-runtime/dotnet-core/dotnet-core_8.x.x.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.19.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.19.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's .NET 8.0.19"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/8.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/dotnet-core/dotnet-core_8.0.19_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.19_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.19_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.19 of the ARM .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.19/dotnet-runtime-8.0.19-linux-arm.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is 'b2ab05f6a29cff2b8440211bc591af0930fb1e9d082b180b95e61b7d4e1b3f79fd2a729b29baab71148780d92c64618ecf8c56a8cf3aca622afb29f487701d82'
+
+SRC_URI[md5sum] = "03517b73f4ae7d44d8f0cbec8b304c52"
+SRC_URI[sha256sum] = "9be2b797ffe39536b3b53d35457d56fa593909f9255e2cf0e6ae5c3aeff98f2e"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.19_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.19_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.19 of the ARM64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.19/dotnet-runtime-8.0.19-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '13f5607daa2eb0f9a0fb6a36193d28abc9454208af5573da8bc5fef5cbeb70b187deadaf6a52b3d46fdcc59c8567db77c293775cfd76a43e81ff99c4b425058c'
+
+SRC_URI[md5sum] = "db82ddd7e238789ff2cd090cb8be6d50"
+SRC_URI[sha256sum] = "29408a6785f4ce6665e4fc2af11aa907bdada355e51db9e27f9ef26a89d2dd9a"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.19_none.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.19_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.19_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.19_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.19 of the X64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.19/dotnet-runtime-8.0.19-linux-x64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '0f66ee564fc9a86b8eae5403f431af59565e62f5eb59f6e50377e72c58ad24552db3b72ecfd824b850a4234faedb213983b89cc479372fc436a553fb086bb9a8'
+
+SRC_URI[md5sum] = "44ee4aeb65b4fbc895ff4a27f1bcfff0"
+SRC_URI[sha256sum] = "485157f6a58b666b4d6422c5693063daf4d6fa314660ac7240cafc5ee73ef1c6"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.1_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.1_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/809134e8-66fa-4f0c-a84a-9e981e9bd2f9/efb33d1a4075101410c82a617f4f7c42/dotnet-runtime-8.0.1-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.1/dotnet-runtime-8.0.1-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '40cd226ee1b25a24eba395a6037d59ae6ead9c0ca625abf3e257564c9308f5e7fccfceab0058f3aa348698ee8be6d10031f23854d1876384476ed171772af299'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.1_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.1_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/39e79317-94d1-4e57-bb90-d5e004f4f3d4/cdcf3c0d8dc2560dcfcb160acb193785/dotnet-runtime-8.0.1-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.1/dotnet-runtime-8.0.1-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '29707882d4fce61eb4b20763473d548570f89f9d028bafb76b646911a5e7bf793dc75e33a6903622d7ba46e9eea0eac000d931cd2f45da118ef05fede6d4079b'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.1_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.1_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/4d5166de-c1ac-45c5-bb8a-d47f8ee93ad9/ffab59440a3eb74359dd3009e4da5a81/dotnet-runtime-8.0.1-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.1/dotnet-runtime-8.0.1-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'cbd03325280ff93cd0edab71c5564a50bb2423980f63d04602914db917c9c811a0068d848cab07d82e3260bff6684ad7cffacc2f449c06fc0b0aa8f845c399b6'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.20.bb
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.20.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 8.0.20 .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/dotnet-core/dotnet-core_8.0.20.inc
+require recipes-runtime/dotnet-core/dotnet-core_8.x.x.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.20.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.20.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's .NET 8.0.20"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/8.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/dotnet-core/dotnet-core_8.0.20_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.20_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.20_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.20 of the ARM .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.20/dotnet-runtime-8.0.20-linux-arm.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '3a15f6539dcdab1d8965e23e852af2998ad868ddc6cee6ccd460a77d9da18df82c6b3730f3367b90b1f7038f93d66f55324e5efd0f7cea5f84dc77d75630b2e5'
+
+SRC_URI[md5sum] = "ce9c49792e7fb206a371023a84c0947c"
+SRC_URI[sha256sum] = "d260b789ec7585fd489c8f42b1f3f451fb96f783290b5cf76bc807a6b1823c4d"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.20_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.20_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.20 of the ARM64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.20/dotnet-runtime-8.0.20-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '58fd19afece5e41bef0ecaf151054d747d13f908f3a627e0fdb73b85ff40bbb5d2aba85aa43ee06d515b9591cbcdd4f87ac1b4e74923dca894df9b7fc59951fb'
+
+SRC_URI[md5sum] = "758fc477b70c1b21555dbc354a5209f2"
+SRC_URI[sha256sum] = "5e02179c1fe8ff4bdc60798b1949340b54d09349ca61d3ba559f52dfffee19d2"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.20_none.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.20_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.20_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.20_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.20 of the X64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.20/dotnet-runtime-8.0.20-linux-x64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '4b801177e009ec710d5e2511500aa60bec95811add50fdc59b00a5c486840c66f00c48f272cf7a2f8129ed158ec5b887d1dd60594e612f749ba48fcf48af9cd2'
+
+SRC_URI[md5sum] = "4718a1f940375632645ca8c8e268ed5f"
+SRC_URI[sha256sum] = "284f308aed1b7f3a782c5172a20e786165d0eeb73a3459eb4f16d45e7adb7ee9"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.21.bb
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.21.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 8.0.21 .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/dotnet-core/dotnet-core_8.0.21.inc
+require recipes-runtime/dotnet-core/dotnet-core_8.x.x.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.21.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.21.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's .NET 8.0.21"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/8.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/dotnet-core/dotnet-core_8.0.21_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.21_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.21_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.21 of the ARM .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.21/dotnet-runtime-8.0.21-linux-arm.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is 'f07d8109e4639fa5f8a9cb7de3f46caea5816dd6459f483287d8b51d407b9426ed5a28dd11b79da9fdd7645ec446ccfd62e63c695fe0e0838eb256abf9719a53'
+
+SRC_URI[md5sum] = "31931b8820ed3991eeeff6f21e6b8ebd"
+SRC_URI[sha256sum] = "85cc081dcf423d97289d2a5eb54e2344b57f52e1fa36580040fcac92231a7816"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.21_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.21_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.21 of the ARM64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.21/dotnet-runtime-8.0.21-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '7eaeadbcca169b2fdd2ba078c242b775d17be887f0e058b936dd6f872c1b7ab3260a6852e398b84f4c9165d0f55bb0fcdebf8b3de26ff980ab7d3a43d320bd45'
+
+SRC_URI[md5sum] = "e34b5381770a41b9c7666ee3c237fb43"
+SRC_URI[sha256sum] = "8198bfdd78ddd18dda6dcd630222388c740ef3b12168cc6eaddd1973846d8028"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.21_none.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.21_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.21_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.21_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 8.0.21 of the X64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.21/dotnet-runtime-8.0.21-linux-x64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is 'b5771f98f89bcb70ba18df234dd82f006ee3b241fe4863485ea649d7c428d12f2e14de620a4ec09f56b9b98b5216c5b216a47f0b5cd9011a383993eef6979015'
+
+SRC_URI[md5sum] = "a834387ea2a38c2cc672e1098daa3ecb"
+SRC_URI[sha256sum] = "1d7a338cada885183b54d43247604e05b8719a08861e47dd032e2a3b8171b3ce"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.2_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.2_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/738dd855-9340-4dda-93b8-e11444113a66/9516b9e2023e158cc2439ac5dd7dbee2/dotnet-runtime-8.0.2-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.2/dotnet-runtime-8.0.2-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'ee03411c04ab240b6356a6fcbe66948d688a90afdade6dc2b0229d9ab3b2df851a66211a2bfb3a5c142e7256fcc04412b64bec8794c1e9117dc2f9babd01adf5'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.2_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.2_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/9de452db-acbe-48eb-b3f0-305a4e48e32a/515bbe7e3e1deef5ab9a4b8123b901ca/dotnet-runtime-8.0.2-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.2/dotnet-runtime-8.0.2-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '12c5f49b7bd63d73cae57949e1520eaebc47732f559f68199ecd3bcca597f2da702352313a20aa100c667ede1d701dc6822f7a4eee9063d1c73d1f451ed832ac'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.2_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.2_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/307e4bf7-53c1-4b03-a2e5-379151ab3a04/140e7502609d45dfd83e4750b4bb5178/dotnet-runtime-8.0.2-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.2/dotnet-runtime-8.0.2-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'f30f72f55b9e97e36107f920e932477183867726a963ea0d4d151f291981877ba253a7175614c60b386b6a37f9192d97d7402dafdad2529369f512698cb9d1dd'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.3_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.3_arm.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/a3caf5aa-a29a-41a2-b3db-7d68b606dc1a/478f27b65c19dafd3c3120fbdeb99295/dotnet-runtime-8.0.3-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.3/dotnet-runtime-8.0.3-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'ff57e94bfeca1c44beef4f960caa9e3600ddab4a75c4df09611a667d95d8aad56f7c8b4b89dd8919a9dacb5a79b90a516e6420d6ce39047f89b9d313d45acc62'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.3_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.3_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/988a1d6e-6bfb-406c-90ba-682f5c11a7fc/28208806b0a6151c4e5d9e1441b01a6f/dotnet-runtime-8.0.3-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.3/dotnet-runtime-8.0.3-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'a78f51500fe180936152f561b3c2385939053aaeb1c2eba5e1353c6427a57fc1c6de8ffcc398afa0d2051ec696813b7c635917f6f0554028b725c58fda981871'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.3_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.3_x64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/ed0c9129-950a-48db-80be-e770daf2db41/53879e5802bc6e76bac55c1b8154ed06/dotnet-runtime-8.0.3-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.3/dotnet-runtime-8.0.3-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '08ad7065abf73d09bd718963bd1277c4736f9d51c7c51849255732db03b59f2321d321235be8be35ca5ef2bbd4f331a0fecaefb48d3e1075659e075bcd1f0169'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.4_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.4_arm.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/a299eeb3-a9c8-42d4-a0ff-61713365c715/0f4d4139df6c700efd4c0d172c2c28eb/dotnet-runtime-8.0.4-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.4/dotnet-runtime-8.0.4-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '4194840a6f1235808d1f1f4ff42046b6f11584c64fca65eb54b65c4dd924400679ae9e1f20efe582dda958f1838c5c125eb72da1d2fdcdd8628dcc20c35c6b88'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.4_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.4_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/761b252b-a0d9-41cd-b1ec-2dc33159c11c/b8285cf82db4ef340a191bfba9a9a73e/dotnet-runtime-8.0.4-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.4/dotnet-runtime-8.0.4-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'd11ce8867dc91d9e9b333753cc7b9677204898485d044dfbbfabe5c5eee43091580a11c3029fca4138cfa9576f84e23fc11bcffa44fcaf5c3d8e617a3cd18802'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.4_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.4_x64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/a3ca3d31-f45b-4e53-ab4d-0f2f221cbc5b/47382078b4b72a66387d0fd6ed9ff963/dotnet-runtime-8.0.4-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.4/dotnet-runtime-8.0.4-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '5c23889d3e6effa85d46c0e1969ce876c686723ae47bddf2cf9c0b1d99affde3f60c04063c2467027aa4163e9a981ef601250a7e8d14ddc6b365c89b24029c80'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.5_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.5_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/b52720a7-9dc4-4b9c-97fa-d1caebdaf946/443750ad6f47c855a395abbd36bb3b3a/dotnet-runtime-8.0.5-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.5/dotnet-runtime-8.0.5-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '84d135e0c18da840f8e5555cf6e8b7d57776ceaccb0aaabeb5c75c54b6b78b3844e09cd9f1ee495caddab52e4b80455423200e23c17cb9ce83bc5df7bd99729e'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.5_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.5_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/00ca4d7a-e529-4384-8ad4-acb8237d540f/a7df4c26e3c0e1dcf8e17d2abb79aad5/dotnet-runtime-8.0.5-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.5/dotnet-runtime-8.0.5-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'cd6c0ac051c3a8b6f3452a5a93600e664e30b9ba14c33948fbbfc21482fe55a8b16268035dd0725c85189d18c83860ea7a7bc96c87d6a4ee6a6083130c5586c3'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.5_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.5_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/baeb5da3-4b77-465b-8816-b29f0bc3e1a9/b04b17a2aae79e5f5635a3ceffbd4645/dotnet-runtime-8.0.5-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.5/dotnet-runtime-8.0.5-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '3efff49feb2e11cb5ec08dcee4e1e8ad92a4d2516b721a98b55ef2ada231cad0c91fd20b71ab5e340047fc837bd02d143449dd32f4f95288f6f659fa6c790eaa'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.6_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.6_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/eda981d2-9e7c-4764-b0f1-e677dc0d89fe/be9ad5e056212ca31ea1ef7a5dd2d9ba/dotnet-runtime-8.0.6-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.6/dotnet-runtime-8.0.6-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'f50a3acef2d10282a2a236c4eed6f8a6e02b929123c297e3a2cd52deb442a7aa9571ea8529fdf6fdc5b140a076f0e69cfd8358cedaf399ec443441a9c6389817'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.6_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.6_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/0039e2c5-d78d-45fb-94c0-e258ff0335fe/c3bff45767f679bbab149398e9ee2c6b/dotnet-runtime-8.0.6-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.6/dotnet-runtime-8.0.6-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '428c5a81938273c5e63b04858dbf2f4e82c9bcfa3bd33f954081238be2fb52aadce99296698eabac72e4be55c61e6c1ff06d2d8d1fd5d6a2d0c7a2917cd50739'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.6_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.6_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/021c3de8-14d5-493f-92dc-2c8f8be76961/6ee3407acebf74631bfc01f14301afa6/dotnet-runtime-8.0.6-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.6/dotnet-runtime-8.0.6-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'c0c5e93d4e68e2075c4c63336dc74246efb704ac9663411351efdefc4cc7da5a7750f44b8a23aebe959bb4308575bead443a41b2524ae03b29ac41929d27e0e0'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.7_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.7_arm.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/1dc20d39-a5c4-4e23-a70b-842fcd6d603a/814d37d9c67811d9d2837905e4330eab/dotnet-runtime-8.0.7-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.7/dotnet-runtime-8.0.7-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'ccfe95a95be3c64d568c6f79df391daf73304fa2c2aedf4616cd9981efe11cac698c157d8375da3afda691b78124cc6672fde7353b0fea4d45da15e003040a2a'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.7_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.7_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/710337b9-9cb6-4bc8-8d13-daeab2578a08/b3ec8c17f85e340820a0ab36a3870168/dotnet-runtime-8.0.7-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.7/dotnet-runtime-8.0.7-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '99e6959a1156d5abc8f0c73b3d493fc1e10a42d48a573226ebcfbdf96bb6fb1c8701db5b3582a4303ce26a4f784e74eb402cb6e5e4bcdbb5dfab8fea221cfe02'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.7_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.7_x64.inc
@@ -4,7 +4,7 @@
 # Copyright cjzzz 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/cf3418ca-0e14-4b76-b615-ac2f2497f8ec/2583028ea52460cb1534d929dc7970fe/dotnet-runtime-8.0.7-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.7/dotnet-runtime-8.0.7-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '88e9ac34ad5ac76eec5499f2eb8d1aa35076518c842854ec1053953d34969c7bf1c5b2dbce245dbace3a18c3b8a4c79d2ef2d2ff105ce9d17cbbdbe813d8b16f'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.8_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.8_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/5e427de4-981a-481e-9fec-fa77b02a7edb/0d156acae55ca1329b6b9a8de70f398f/dotnet-runtime-8.0.8-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.8/dotnet-runtime-8.0.8-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'c87af5aaaf32e18ccdc2965179c65aabae5e0e9e8ea209f6c364270ce2e4afffea979ca22e143de4674e36a2b12c66b575588ae219f16636aca7121440240288'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.8_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.8_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/ac04b123-0542-4e80-9216-93f51a6814b3/d110733c152d34ab4eedb435ccfdab4d/dotnet-runtime-8.0.8-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.8/dotnet-runtime-8.0.8-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '246fb7e5edb51db93421c6bb7420f7a358430b98b224a71fb70e71a2bce0bc91f853aa89109f2188b0ab28532a245c3d52baac163463e01a02019dea37fd39f2'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_8.0.8_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_8.0.8_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/68c87f8a-862c-4870-a792-9c89b3c8aa2d/2319ebfb46d3a903341966586e8b0898/dotnet-runtime-8.0.8-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.8/dotnet-runtime-8.0.8-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '8f5220098c562fa3490417748eb9f4f9ca1551f7155728b9ebb1924359c63c18dedef643bcd89ec67b59cb5b1b9de7283ee156ef381ffb16801b516dba9b1b0f'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.0_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.0_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/8f639af4-29e2-474e-ad2d-ad1845c09e21/d6a1fac24aa5bed41dcc8c35017a44f4/dotnet-runtime-9.0.0-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is 'fab552df6d884090aba1f658c8812b5369e9bea17e6a1f905145cde512772b57db5d5cf586c6c2b7f2e56a8cb83c206f0cf7594bcf42d32844b8103538bd883f'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.0_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.0_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/3ae34de0-5928-47c4-9abb-e0b8f795c256/1ea2ed5a50af003121ebf32cb218258e/dotnet-runtime-9.0.0-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '4f9c2dd544af0b8540c16352b9f01f75f828b8e4e084057a300a4dec652fb3d6532906cdd4246399cc13f16b571b17575812ec2f9c297e27bbed678baf4b2fde'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.0_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.0_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2024
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/282bb881-c2ae-4250-b814-b362745073bd/6e15021d23f704c0d457c820a69a3de6/dotnet-runtime-9.0.0-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '5176bd68637646cd36fce7a88f83effe1065fb075e6d4a46b8be3c33d5a8394740577f0ed4f8b4fb13fa69fe83b229eb55ab7f45caac90849bf0392a670ed5af'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.10.bb
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.10.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 9.0.10 .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/dotnet-core/dotnet-core_9.0.10.inc
+require recipes-runtime/dotnet-core/dotnet-core_9.x.x.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.10.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.10.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's .NET 9.0.10"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/9.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/dotnet-core/dotnet-core_9.0.10_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.10_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.10_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.10 of the ARM .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.10/dotnet-runtime-9.0.10-linux-arm.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '89e4ef0919910b868c9c7c47e299c9b341747ecf1fcfc5e9dfc54f5b56bad40a9cac83e5f544644d1a8daa1698e2d77d4fb420ef817747f8510103e1f1227233'
+
+SRC_URI[md5sum] = "30e57a06bb500cbc76f9d49ad0739e89"
+SRC_URI[sha256sum] = "616584198878f055a6b632ef44fad386293b1b440affdb36829ccb0c484e3e6f"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.10_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.10_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.10 of the ARM64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.10/dotnet-runtime-9.0.10-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '7b0d908ad54e04840a6ce6afcf21a52309ebda10931218a66a5e2f63c3dfde8d5d267f503e2fa82e2e2b6819a92052525d14334186d77c0878d02fc7d754b96b'
+
+SRC_URI[md5sum] = "d2bd264efdf1b0cb313a9f8fbbbec421"
+SRC_URI[sha256sum] = "fe4646eb50441469a2c9ba4d86313298827237b61f3dc3fc57a985b4bbf55ae6"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.10_none.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.10_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.10_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.10_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.10 of the X64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.10/dotnet-runtime-9.0.10-linux-x64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '6ceb35ddc6f4e2c039a3879e2f18fe73f427b924b868b0309bf61f7d23636e49d52b5cdbab5d97f8b4e08769abf3ce821e7acd802225ef848826a0165c6ca7c2'
+
+SRC_URI[md5sum] = "f5ce2a393ec99abdfcb214e21b2da608"
+SRC_URI[sha256sum] = "011a9dad66b3cf824e7a61c334b0a97a43cdfbc5121b0d274383f77e2ff67392"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.3_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.3_arm.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/6a2bc9fa-ffb0-4113-993e-902e2049ffc9/fb2589c89729fabade52bc737605ed93/dotnet-runtime-9.0.3-linux-arm.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.3/dotnet-runtime-9.0.3-linux-arm.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '22b35dca40dba8a6bc6663c63c04a3e6edf59f04b1db3bf792a1e64b573c3896f65e322cdbe8c1522009c2e81d94fe0ef85ab436e2961e81f4d7cc2123ba33e3'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.3_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.3_arm64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/79e65a77-46e2-47b5-9bf4-efa8a6426308/211a9c0c2952d0bbdb0aa5eb1348e2b6/dotnet-runtime-9.0.3-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.3/dotnet-runtime-9.0.3-linux-arm64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '0b18859800c75d293b05b58938b7c3ebd9a7aa5d5b163c8d5a08aa84f95017d2d0114dd6f3a688bce9974c43dbd073a930977b7ccfe06577207a67f00319d20c'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.3_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.3_x64.inc
@@ -4,7 +4,7 @@
 # Copyright Richard Dunkley 2025
 # Auto-generated using meta_dotnet_core_gen
 ###################################################################################################
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/a58fcc04-99ee-4dea-aa5d-d6d22c4040dc/4433f4e97ad4658bd76f52acc1cb9c21/dotnet-runtime-9.0.3-linux-x64.tar.gz;subdir=dotnet-${PV}"
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.3/dotnet-runtime-9.0.3-linux-x64.tar.gz;subdir=dotnet-${PV}"
 
 # SHA-512 hash is '4b16a57e94592fb9712421ed90c025fc3b4f9039faea37b432b6d8a3e8caf192dead732fb84bbdca9dfa4ed40ddb46078dd3c2710801c92aee8e21c084bfd664'
 

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.8.bb
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.8.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 9.0.8 .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/dotnet-core/dotnet-core_9.0.8.inc
+require recipes-runtime/dotnet-core/dotnet-core_9.x.x.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.8.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.8.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's .NET 9.0.8"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/9.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/dotnet-core/dotnet-core_9.0.8_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.8_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.8_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.8 of the ARM .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.8/dotnet-runtime-9.0.8-linux-arm.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '5e2b65c2039d66e1c6c9ab1e92bbd487fcd1bd7a6123c170beacdb1ce24688d7349e84ae8b386bd758bd2472b736d18edea8370cc63eb55fac0aab3565880fde'
+
+SRC_URI[md5sum] = "06891197a9bd20e0a90b6cbe2cabb73e"
+SRC_URI[sha256sum] = "cd473869e6c3c202cf026d0b838079862371bbb0adccbe853d830f6ea61cf62e"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.8_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.8_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.8 of the ARM64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.8/dotnet-runtime-9.0.8-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '3015e95ff0c373b8d59491cf1c320c80f4ec7418d63400bf6508d4e25e71a47db2854915348ab186e58a92d5ac2f20fbec13d63df5c5f601ff4af5f29c3d9cd3'
+
+SRC_URI[md5sum] = "91bfa581b974bc4b7c1f790345f1f14d"
+SRC_URI[sha256sum] = "72fcafdc3c0a572d9c578bb8d9447142a2be7a31afde8b1482b18628dfa8d43e"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.8_none.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.8_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.8_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.8_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.8 of the X64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.8/dotnet-runtime-9.0.8-linux-x64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is 'f7696ea2a30a12bad0c8f7321ac42843ced307184d894c94a64c85289b3cf30936df373ff58543ce9b77605a80243d1fc777bc959575634aaad9caa880fbf866'
+
+SRC_URI[md5sum] = "740d00b337b94f73e9259f3583f34863"
+SRC_URI[sha256sum] = "fdaba6196211593668d1da726580228c64f6be3f4def37c301dcc2fecfa2172d"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.9.bb
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.9.bb
@@ -1,0 +1,10 @@
+###################################################################################################
+# Contains the recipe to download the release binaries from Microsoft for the version
+# 9.0.9 .Net runtime.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+
+require recipes-runtime/dotnet-core/dotnet-core_9.0.9.inc
+require recipes-runtime/dotnet-core/dotnet-core_9.x.x.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.9.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.9.inc
@@ -1,0 +1,17 @@
+###################################################################################################
+# Contains additional parameters for the recipe to download the release binaries from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SUMMARY = "Contains the binaries for Microsoft's .NET 9.0.9"
+HOMEPAGE = "https://dotnet.microsoft.com/download/dotnet/9.0"
+
+DOTNET_RUNTIME_ARCH = "none"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86-64 = "x64"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
+
+# This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
+require recipes-runtime/dotnet-core/dotnet-core_9.0.9_${DOTNET_RUNTIME_ARCH}.inc
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.9_arm.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.9_arm.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.9 of the ARM .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.9/dotnet-runtime-9.0.9-linux-arm.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is 'ac9c6ce4d43e8bc62e653d345d32b54186944ef778711f7f8352dfbe3e5fba863f8e088771d29efbfd2df71da1512861b2102f75d2a74bb288d510b1fa294584'
+
+SRC_URI[md5sum] = "66515a3a1544446708940a8c1634452b"
+SRC_URI[sha256sum] = "fea9b92870bbea63b0d4d5cf08ca2cf8d3f1bbedfddec39910839698f23164c3"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.9_arm64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.9_arm64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.9 of the ARM64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.9/dotnet-runtime-9.0.9-linux-arm64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '4868c06467cb5db0c70d4037631765d639f6e0fab780d3631f04b22ff3afeff88aa5b99004886da06f6e443967819234c45915d2929c066edd8524fe25c51d0b'
+
+SRC_URI[md5sum] = "a5f3953da437e6432d8f91a2c3c3c601"
+SRC_URI[sha256sum] = "2b71d6caffe20658e025cbf4459f70f2704c943e515b96ebb969a282619c5b51"
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.9_none.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.9_none.inc
@@ -1,0 +1,6 @@
+###################################################################################################
+# Dummy file in case the architecture isn't supported (prevents Bitbaker parser from crashing).
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+

--- a/recipes-runtime/dotnet-core/dotnet-core_9.0.9_x64.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_9.0.9_x64.inc
@@ -1,0 +1,13 @@
+###################################################################################################
+# Contains the URL and checksums to download version 9.0.9 of the X64 .Net
+# runtime from Microsoft.
+# Copyright JvZ 2025
+# Auto-generated using meta_dotnet_core_gen
+###################################################################################################
+SRC_URI = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.9/dotnet-runtime-9.0.9-linux-x64.tar.gz;subdir=dotnet-${PV}"
+
+# SHA-512 hash is '4faf7e615880e3680681e18108e8f1288074fd43e6ac0cd1c244b56e8bff7a6ea8bda2a71ecd84bc0091094abcbf792a9da1faaf271fd43129773642e27b25d7'
+
+SRC_URI[md5sum] = "871e1d298772d11a18862535508af13d"
+SRC_URI[sha256sum] = "61a029c5749d7840142277638b04d57caf31918eec39bf952914caca5ae4fe0a"
+


### PR DESCRIPTION
Ran the generation tool get the recipes for .net 9.0.10 which fixes [CVE-2025-55315](https://github.com/dotnet/aspnetcore/issues/64033)  