### PR TITLE
fix missing .txt file handling in aspnet-core_10.x.x.inc

### DIFF
--- a/recipes-runtime/aspnet-core/aspnet-core_10.x.x.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_10.x.x.inc
@@ -46,7 +46,8 @@ do_install:prepend () {
 		install -m 0644 "$file" ${D}${datadir}/dotnet/shared/Microsoft.AspNetCore.App/${PV}/
 	done
 	for file in ${S}/shared/Microsoft.AspNetCore.App/${PV}/*.txt; do
-		install -m 0644 "$file" ${D}${datadir}/dotnet/shared/Microsoft.AspNetCore.App/${PV}/
+    	[ -e "$file" ] || continue
+    	install -m 0644 "$file" ${D}${datadir}/dotnet/shared/Microsoft.AspNetCore.App/${PV}/
 	done
 
 	install -d ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App/${PV}/


### PR DESCRIPTION
`https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0/aspnetcore-runtime-10.0.0-linux-x64.tar.gz` doesn't contain any *.txt file in its `shared\Microsoft.AspNetCore.App\10.0.0` folder

The glob *.txt does not expand. Instead, the literal string *.txt is passed to the for loop. 

Adding `shopt -s nullglob` somewhere at the beginning of the script would also do the trick.